### PR TITLE
FIX: Remove eval statements from production build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 module.exports = {
-    devtool: 'eval-source-map',
+    devtool: 'source-map',
     entry: './src/index.js',
     output: {
         path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
Fixes https://github.com/silverstripe/react-injector/issues/5

Note this PR includes the new dist file and source mappings. You could take my word for it, but the community would probably prefer an official maintainer from the SilverStripe project to re-compile and distribute these.